### PR TITLE
fix(ConferenceCall): fix infinite spinner

### DIFF
--- a/packages/ringcentral-integration/modules/CallMonitor/index.js
+++ b/packages/ringcentral-integration/modules/CallMonitor/index.js
@@ -5,9 +5,7 @@ import RcModule from '../../lib/RcModule';
 import moduleStatuses from '../../enums/moduleStatuses';
 import actionTypes from './actionTypes';
 import callDirections from '../../enums/callDirections';
-import getCallMonitorReducer, {
-  getCallMatchedReducer
-} from './getCallMonitorReducer';
+import getCallMonitorReducer, { getCallMatchedReducer } from './getCallMonitorReducer';
 import normalizeNumber from '../../lib/normalizeNumber';
 import {
   isRinging,


### PR DESCRIPTION
Because there's a chance that the session closed before the _mergeToConference() finishing, so we
need to add the fucntion finishing signal to the door of sip instances' terminations. And also we
have discovered that if we close the session initiatively after the bring-in, the session will still
remain in the conference, so we do so to prevent the remaining session issue when duplicated
sessions exist in a same conference.

BREAKING CHANGE: 
* setCapatity
* setSpanForBringIn