### PR TITLE
fix(ConferenceCallMergeCtrlPage): session.unhold()->webphone.resume()

### DIFF
--- a/packages/ringcentral-widgets/containers/ConferenceCallMergeCtrlPage/index.js
+++ b/packages/ringcentral-widgets/containers/ConferenceCallMergeCtrlPage/index.js
@@ -64,7 +64,7 @@ function mapToFunctions(_, {
          * because session termination operation in conferenceCall._mergeToConference,
          * need to wait for webphone.getActiveSessionIdReducer to update
          */
-        conferenceData.session.unhold();
+        webphone.resume(conferenceData.session.id);
         return;
       }
       if (!conferenceData) {


### PR DESCRIPTION
use webphone.resume(conferenceData.session.id) to trigger the redux