### PR TITLE
feat(CallMonitor, ConferenceCall, Webphone): fix session sorting

### DIFF
--- a/packages/ringcentral-integration/modules/CallMonitor/index.js
+++ b/packages/ringcentral-integration/modules/CallMonitor/index.js
@@ -14,7 +14,7 @@ import {
   isCallConnected,
 } from '../../lib/callLogHelpers';
 import ensureExist from '../../lib/ensureExist';
-import { isRing, isOnHold } from '../Webphone/webphoneHelper';
+import { isRing, isOnHold, sortSession } from '../Webphone/webphoneHelper';
 
 function matchWephoneSessionWithAcitveCall(sessions, callItem) {
   if (!sessions || !callItem.sipData) {
@@ -236,6 +236,11 @@ export default class CallMonitor extends RcModule {
             activityMatches: (activityMapping[callItem.sessionId]) || [],
             toNumberEntity,
           };
+        }).sort((l, r) => {
+          if (!l.webphoneSession || !r.webphoneSession) {
+            return false;
+          }
+          return sortSession(l.webphoneSession, r.webphoneSession);
         });
         return calls;
       }

--- a/packages/ringcentral-integration/modules/ConferenceCall/index.js
+++ b/packages/ringcentral-integration/modules/ConferenceCall/index.js
@@ -518,13 +518,20 @@ export default class ConferenceCall extends RcModule {
   }
 
   setCapatity(capacity = MAXIMUM_CAPACITY) {
+    if (typeof capacity !== 'number') {
+      throw new Error('The capcity must be a number');
+    }
     this.capacity = capacity;
+    return capacity;
   }
 
   setTimeout(timeout = DEFAULT_TIMEOUT) {
+    if (typeof timeout !== 'number') {
+      throw new Error('The timeout must be a number');
+    }
     this._timout = timeout;
+    return timeout;
   }
-
   _init() {
     this.store.dispatch({
       type: this.actionTypes.initSuccess

--- a/packages/ringcentral-integration/modules/ConferenceCall/index.js
+++ b/packages/ringcentral-integration/modules/ConferenceCall/index.js
@@ -607,8 +607,13 @@ export default class ConferenceCall extends RcModule {
     }
     const { id } = await this.makeConference(true);
 
-    await new Promise((resolve) => {
-      this.conferences[id].session.on('accepted', () => resolve());
+    await new Promise((resolve, reject) => {
+      const session = this.conferences[id].session;
+      session.on('accepted', () => resolve());
+      session.on('cancel', () => reject(new Error('conferecing cancel')));
+      session.on('failed', () => reject(new Error('conferecing failed')));
+      session.on('rejected', () => reject(new Error('conferecing rejected')));
+      session.on('terminated', () => reject(new Error('conferecing terminated')));
     });
     await this._mergeToConference(webphoneSessions);
     return id;

--- a/packages/ringcentral-integration/modules/Webphone/getWebphoneReducer.js
+++ b/packages/ringcentral-integration/modules/Webphone/getWebphoneReducer.js
@@ -1,7 +1,7 @@
 import { combineReducers } from 'redux';
 import getModuleStatusReducer from '../../lib/getModuleStatusReducer';
 import connectionStatus from './connectionStatus';
-import { isRing, isOnHold } from './webphoneHelper';
+import { isRing, isOnHold, sortSession } from './webphoneHelper';
 
 export function getVideoElementPreparedReducer(types) {
   return (state = false, { type }) => {
@@ -86,7 +86,7 @@ export function getActiveSessionIdReducer(types) {
         }
         onHoldSessions =
           sessions.filter(sessionItem => isOnHold(sessionItem));
-        if (onHoldSessions && onHoldSessions[0]) {
+        if (onHoldSessions.length && onHoldSessions[0]) {
           return onHoldSessions[0].id;
         }
         return null;
@@ -155,7 +155,7 @@ export function getSessionsReducer(types) {
   return (state = [], { type, sessions }) => {
     switch (type) {
       case types.updateSessions:
-        return sessions;
+        return sessions.sort(sortSession);
       case types.destroySessions:
         return [];
       default:

--- a/packages/ringcentral-integration/modules/Webphone/index.js
+++ b/packages/ringcentral-integration/modules/Webphone/index.js
@@ -701,6 +701,7 @@ export default class Webphone extends RcModule {
     session.on('hold', () => {
       console.log('Event: hold');
       session.callStatus = sessionStatus.onHold;
+      session.lastHoldingTime = +new Date();
       this._updateSessions();
     });
     session.on('unhold', () => {

--- a/packages/ringcentral-integration/modules/Webphone/webphoneHelper.js
+++ b/packages/ringcentral-integration/modules/Webphone/webphoneHelper.js
@@ -36,7 +36,8 @@ export function normalizeSession(session) {
     recordStatus: session.recordStatus || recordStatus.idle,
     contactMatch: session.contactMatch,
     minimized: !!session.minimized,
-    data: session.data || null
+    data: session.data || null,
+    lastHoldingTime: session.lastHoldingTime || 0
   };
 }
 
@@ -50,4 +51,11 @@ export function isRing(session) {
 
 export function isOnHold(session) {
   return !!(session && session.callStatus === sessionStatus.onHold);
+}
+
+export function sortSession(l, r) {
+  if (r.lastHoldingTime !== l.lastHoldingTime) {
+    return r.lastHoldingTime - l.lastHoldingTime;
+  }
+  return r.startTime - l.startTime;
 }

--- a/packages/ringcentral-widgets/components/ActiveCallItem/index.js
+++ b/packages/ringcentral-widgets/components/ActiveCallItem/index.js
@@ -75,6 +75,7 @@ function WebphoneButtons({
   showMergeCall,
   onMergeCall,
   disableMerge,
+  currentLocale,
 }) {
   if (!session || !webphoneAnswer || !webphoneHangup) {
     return null;
@@ -83,9 +84,9 @@ function WebphoneButtons({
   let resumeFunc = webphoneResume;
   let endIcon = EndIcon;
   const mergeIcon = MergeIntoConferenceIcon;
-  let rejectTitle = i18n.getString('hangup');
-  const acceptTitle = i18n.getString('accept');
-  const mergeTitle = i18n.getString('mergeToConference');
+  let rejectTitle = i18n.getString('hangup', currentLocale);
+  const acceptTitle = i18n.getString('accept', currentLocale);
+  const mergeTitle = i18n.getString('mergeToConference', currentLocale);
   if (
     session.direction === callDirections.inbound &&
     session.callStatus === sessionStatus.connecting
@@ -93,7 +94,7 @@ function WebphoneButtons({
     hangupFunc = webphoneReject;
     resumeFunc = webphoneAnswer;
     endIcon = VoicemailIcon;
-    rejectTitle = i18n.getString('toVoicemail');
+    rejectTitle = i18n.getString('toVoicemail', currentLocale);
   }
   return (
     <div className={styles.webphoneButtons}>
@@ -154,6 +155,7 @@ WebphoneButtons.propTypes = {
   showMergeCall: PropTypes.bool,
   onMergeCall: PropTypes.func,
   disableMerge: PropTypes.bool,
+  currentLocale: PropTypes.string.isRequired,
 };
 
 WebphoneButtons.defaultProps = {
@@ -493,6 +495,7 @@ export default class ActiveCallItem extends Component {
             showMergeCall={showMergeCall}
             onMergeCall={onMergeCall}
             disableMerge={disableMerge}
+            currentLocale={currentLocale}
           />
           {extraButton}
         </div>

--- a/packages/ringcentral-widgets/components/ActiveCallPad/i18n/en-US.js
+++ b/packages/ringcentral-widgets/components/ActiveCallPad/i18n/en-US.js
@@ -8,6 +8,7 @@ export default {
   stopRecord: 'Stop',
   record: 'Record',
   add: 'Add',
+  mergeToConference: 'Merge',
   transfer: 'Transfer',
   flip: 'Flip',
 };

--- a/packages/ringcentral-widgets/components/ActiveCallPad/index.js
+++ b/packages/ringcentral-widgets/components/ActiveCallPad/index.js
@@ -181,7 +181,7 @@ export default function ActiveCallPad(props) {
   } else {
     conferenceCallButton = props.layout === callCtrlLayout.mergeCtrl ?
       (
-        <div className={styles.button}>
+        <div className={styles.button} title={i18n.getString('mergeToConference', props.currentLocale)}>
           <CircleButton
             className={props.mergeDisabled ? styles.disabled : styles.mergeButton}
             onClick={props.mergeDisabled ? i => i : () => {
@@ -196,7 +196,7 @@ export default function ActiveCallPad(props) {
         </div>
       )
       : (
-        <div className={styles.button}>
+        <div className={styles.button} title={i18n.getString('add', props.currentLocale)}>
           <CircleButton
             className={props.addDisabled ? styles.disabled : styles.combineButton}
             onClick={props.addDisabled ? i => i : () => {

--- a/packages/ringcentral-widgets/components/ActiveCallsPanel/ConfirmMergeModal.js
+++ b/packages/ringcentral-widgets/components/ActiveCallsPanel/ConfirmMergeModal.js
@@ -38,8 +38,8 @@ export default function ConfirmMergeModal({
         {i18n.getString('confirmMergeToConference', currentLocale)}
       </div>
       <div className={styles.content}>
-        <p className={styles.contentText}><ConferenceCallIcon /><span>{i18n.getString('conferenceCall')}</span></p>
-        <span title={i18n.getString('mergeToConference')} className={styles.webphoneButton}>
+        <p className={styles.contentText}><ConferenceCallIcon /><span>{i18n.getString('conferenceCall', currentLocale)}</span></p>
+        <span title={i18n.getString('mergeToConference', currentLocale)} className={styles.webphoneButton}>
           <CircleButton
             className={styles.mergeButton}
             onClick={(e) => {

--- a/packages/ringcentral-widgets/containers/ConferenceCallMergeCtrlPage/index.js
+++ b/packages/ringcentral-widgets/containers/ConferenceCallMergeCtrlPage/index.js
@@ -68,7 +68,6 @@ function mapToFunctions(_, {
         return;
       }
       if (!conferenceData) {
-        await sleep(200);
         await webphone.resume(session.id);
         routerInteraction.push('/conferenceCall/mergeCtrl');
       }


### PR DESCRIPTION
* decsending sorting the sessions and call log by recording last onhold time
* remve the waiting span for bring-in, but using the SIP `accepted` event since the new service is deployed

BREAKING CHANGE: add session sorting algorithm

* https://jira.ringcentral.com/browse/RCINT-7708
* https://jira.ringcentral.com/browse/RCINT-7773