### PR TITLE
fix(Webphone, ConferenceCall): avoid call control glitching when merging

### DIFF
--- a/packages/ringcentral-integration/modules/CallMonitor/index.js
+++ b/packages/ringcentral-integration/modules/CallMonitor/index.js
@@ -12,7 +12,7 @@ import {
   sortByStartTime,
 } from '../../lib/callLogHelpers';
 import ensureExist from '../../lib/ensureExist';
-import { isRing, isOnHold, sortByLastHoldingTime } from '../Webphone/webphoneHelper';
+import { isRing, isOnHold, sortByLastHoldingTimeDesc } from '../Webphone/webphoneHelper';
 
 function matchWephoneSessionWithAcitveCall(sessions, callItem) {
   if (!sessions || !callItem.sipData) {
@@ -168,7 +168,7 @@ export default class CallMonitor extends RcModule {
             webphoneSession,
           };
         }).sort((l, r) => (
-          sortByLastHoldingTime(l.webphoneSession, r.webphoneSession)
+          sortByLastHoldingTimeDesc(l.webphoneSession, r.webphoneSession)
         ));
       },
     );

--- a/packages/ringcentral-integration/modules/ConferenceCall/index.js
+++ b/packages/ringcentral-integration/modules/ConferenceCall/index.js
@@ -379,7 +379,7 @@ export default class ConferenceCall extends RcModule {
        * HACK: we need to preserve the merging session in prevent the glitch of
        * the call control page.
        */
-      this._webphone.updateSessionCaching(sessionDatas[webphoneSessions.length - 1]);
+      this._webphone.updateSessionCaching(sessionDatas);
 
       const pSips = sipInstances.map((instance) => {
         const p = new Promise((resolve) => {

--- a/packages/ringcentral-integration/modules/ConferenceCall/index.js
+++ b/packages/ringcentral-integration/modules/ConferenceCall/index.js
@@ -623,7 +623,7 @@ export default class ConferenceCall extends RcModule {
       this.stopPollingConferenceStatus(conferenceId);
       // for the sake of participants ordering, we can't concurrently bring in the participants
       for (const webphoneSession of webphoneSessions) {
-        await this.bringInToConference(conferenceId, webphoneSession);
+        await this.bringInToConference(conferenceId, webphoneSession, true);
       }
       if (!this.conferences[conferenceId].profiles.length) {
         throw new Error('bring-in operations failed, not all intended parties were brought in');

--- a/packages/ringcentral-integration/modules/Webphone/actionTypes.js
+++ b/packages/ringcentral-integration/modules/Webphone/actionTypes.js
@@ -23,4 +23,6 @@ export default new Enum([
   'videoElementPrepared',
   'getUserMediaSuccess',
   'getUserMediaError',
+  'updateSessionCaching',
+  'clearSessionCaching',
 ], 'webphone');

--- a/packages/ringcentral-integration/modules/Webphone/getWebphoneReducer.js
+++ b/packages/ringcentral-integration/modules/Webphone/getWebphoneReducer.js
@@ -170,6 +170,20 @@ export function getSessionsReducer(types) {
   };
 }
 
+// HACK: for conference call merging
+export function getCachedSessionReducer(types) {
+  return (state = null, { type, session }) => {
+    switch (type) {
+      case types.updateSessionCaching:
+        return session;
+      case types.clearSessionCaching:
+        return null;
+      default:
+        return state;
+    }
+  };
+}
+
 export default function getWebphoneReducer(types) {
   return combineReducers({
     status: getModuleStatusReducer(types),
@@ -182,5 +196,6 @@ export default function getWebphoneReducer(types) {
     ringSessionId: getRingSessionIdReducer(types),
     sessions: getSessionsReducer(types),
     lastEndedSessions: getLastEndedSessionsReducer(types),
+    cachedSession: getCachedSessionReducer(types),
   });
 }

--- a/packages/ringcentral-integration/modules/Webphone/getWebphoneReducer.js
+++ b/packages/ringcentral-integration/modules/Webphone/getWebphoneReducer.js
@@ -1,7 +1,7 @@
 import { combineReducers } from 'redux';
 import getModuleStatusReducer from '../../lib/getModuleStatusReducer';
 import connectionStatus from './connectionStatus';
-import { isRing, isOnHold, sortByLastHoldingTime } from './webphoneHelper';
+import { isRing, isOnHold, sortByLastHoldingTimeDesc } from './webphoneHelper';
 
 export function getVideoElementPreparedReducer(types) {
   return (state = false, { type }) => {
@@ -161,7 +161,7 @@ export function getSessionsReducer(types) {
   return (state = [], { type, sessions }) => {
     switch (type) {
       case types.updateSessions:
-        return sessions.sort(sortByLastHoldingTime);
+        return sessions.sort(sortByLastHoldingTimeDesc);
       case types.destroySessions:
         return [];
       default:
@@ -171,11 +171,11 @@ export function getSessionsReducer(types) {
 }
 
 // HACK: for conference call merging
-export function getCachedSessionReducer(types) {
-  return (state = null, { type, session }) => {
+export function getCachedSessionsReducer(types) {
+  return (state = null, { type, sessions }) => {
     switch (type) {
       case types.updateSessionCaching:
-        return session;
+        return sessions;
       case types.clearSessionCaching:
         return null;
       default:
@@ -196,6 +196,6 @@ export default function getWebphoneReducer(types) {
     ringSessionId: getRingSessionIdReducer(types),
     sessions: getSessionsReducer(types),
     lastEndedSessions: getLastEndedSessionsReducer(types),
-    cachedSession: getCachedSessionReducer(types),
+    cachedSessions: getCachedSessionsReducer(types),
   });
 }

--- a/packages/ringcentral-integration/modules/Webphone/webphoneHelper.js
+++ b/packages/ringcentral-integration/modules/Webphone/webphoneHelper.js
@@ -53,12 +53,16 @@ export function isOnHold(session) {
   return !!(session && session.callStatus === sessionStatus.onHold);
 }
 
-export function sortByLastHoldingTime(l, r) {
+export function sortByCreationTimeDesc(l, r) {
+  return r.startTime - l.startTime;
+}
+
+export function sortByLastHoldingTimeDesc(l, r) {
   if (!l || !r) {
     return 0;
   }
   if (r.lastHoldingTime !== l.lastHoldingTime) {
     return r.lastHoldingTime - l.lastHoldingTime;
   }
-  return r.startTime - l.startTime;
+  return sortByCreationTimeDesc(l, r);
 }

--- a/packages/ringcentral-widgets-demo/dev-server/Phone.js
+++ b/packages/ringcentral-widgets-demo/dev-server/Phone.js
@@ -206,11 +206,11 @@ export default class BasePhone extends RcModule {
     webphone._onCallEndFunc = (session, currentSession) => {
       if (
         routerInteraction.currentPath === '/conferenceCall/mergeCtrl' &&
-        conferenceCall.state.mergingPair.from &&
-        conferenceCall.state.mergingPair.from.id === session.id &&
-        currentSession
+        webphone.cachedSession
+        && ((currentSession
+          && currentSession.id === webphone.cachedSession.id
+        ) || !currentSession)
       ) {
-        routerInteraction.push('/calls/active');
         return;
       }
 

--- a/packages/ringcentral-widgets-demo/dev-server/Phone.js
+++ b/packages/ringcentral-widgets-demo/dev-server/Phone.js
@@ -206,9 +206,9 @@ export default class BasePhone extends RcModule {
     webphone._onCallEndFunc = (session, currentSession) => {
       if (
         routerInteraction.currentPath === '/conferenceCall/mergeCtrl' &&
-        webphone.cachedSession
+        webphone.cachedSessions
         && ((currentSession
-          && currentSession.id === webphone.cachedSession.id
+          && webphone.cachedSessions.find(cachedSession => cachedSession.id === currentSession.id)
         ) || !currentSession)
       ) {
         return;

--- a/packages/ringcentral-widgets/components/ActiveCallPanel/ConferenceInfo.js
+++ b/packages/ringcentral-widgets/components/ActiveCallPanel/ConferenceInfo.js
@@ -16,7 +16,7 @@ export default function ConferenceInfo({
       onClick={(e) => { e.preventDefault(); onClick(); }}
     >
       {
-        Array.isArray(displayedProfiles)
+        Array.isArray(displayedProfiles) && displayedProfiles.length
         ? (
           <div className={styles.avatarContainer}>
             {
@@ -35,12 +35,11 @@ export default function ConferenceInfo({
                 </div>
               )
             )
+          }{
+            remains
+              ? (<div className={classnames(styles.avatar, styles.remains)}>{`+${remains}`}</div>)
+              : null
           }
-            {
-          remains ? (
-            <div className={classnames(styles.avatar, styles.remains)}>{`+${remains}`}</div>
-          ) : null
-        }
           </div>
         )
         : (

--- a/packages/ringcentral-widgets/components/ActiveCallPanel/ConferenceInfo.js
+++ b/packages/ringcentral-widgets/components/ActiveCallPanel/ConferenceInfo.js
@@ -16,24 +16,40 @@ export default function ConferenceInfo({
       onClick={(e) => { e.preventDefault(); onClick(); }}
     >
       {
-        Array.isArray(displayedProfiles) ? (
+        Array.isArray(displayedProfiles)
+        ? (
           <div className={styles.avatarContainer}>
-            {displayedProfiles.map(
-          ({ avatarUrl, toUserName }, idx) => (
-            <div
-              key={`${toUserName}_${idx}`}
-              className={styles.avatar}
-              style={avatarUrl ? { backgroundImage: `url(${avatarUrl})` } : { backgroundColor: '#fff' }}>
-              {avatarUrl ? null : <i className={classnames(dynamicsFont.portrait, styles.icon)} /> }
-            </div>
-        ))}
+            {
+              displayedProfiles.map(
+              ({ avatarUrl, toUserName }, idx) => (
+                <div
+                  key={`${toUserName}_${idx}`}
+                  className={styles.avatar}
+                  style={avatarUrl
+                    ? { backgroundImage: `url(${avatarUrl})` }
+                    : { backgroundColor: '#fff' }
+                  }>
+                  {avatarUrl
+                    ? null
+                    : <i className={classnames(dynamicsFont.portrait, styles.icon)} /> }
+                </div>
+              )
+            )
+          }
             {
           remains ? (
             <div className={classnames(styles.avatar, styles.remains)}>{`+${remains}`}</div>
           ) : null
         }
           </div>
-        ) : null
+        )
+        : (
+          <div className={styles.avatarContainer}>
+            <div className={styles.avatar} style={{ backgroundColor: '#fff' }}>
+              <i className={classnames(dynamicsFont.portrait, styles.icon)} />
+            </div>
+          </div>
+        )
       }
       <p className={styles.info}>
         {i18n.getString('conferenceCall')}

--- a/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
+++ b/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
@@ -303,7 +303,7 @@ function mapToProps(_, {
     // in case webphone.activeSession has not been updated yet
     || !Object.keys(currentSession).length;
     // update
-    mergeDisabled = newVal;
+    mergeDisabled = newVal || !Object.keys(currentSession.data).length;
     addDisabled = newVal;
   }
 


### PR DESCRIPTION
because we need to prevent the glitching of the call control page during the process of  merging 2 calls together, so we need to cached the last outbound call of the merging process

BREAKING CHANGE: add cached session in webphone module

https://jira.ringcentral.com/browse/RCINT-7708