### PR TITLE
fix(CallMonitor, Webphone): fix all calls list glitch when merging

### DIFF
--- a/packages/ringcentral-integration/modules/CallMonitor/actionTypes.js
+++ b/packages/ringcentral-integration/modules/CallMonitor/actionTypes.js
@@ -4,4 +4,6 @@ import moduleActionTypes from '../../enums/moduleActionTypes';
 export default new Enum([
   ...Object.keys(moduleActionTypes),
   'setData',
+  'updateCallsCaching',
+  'clearCallsCaching',
 ], 'callMonitorAcionTypes');

--- a/packages/ringcentral-integration/modules/CallMonitor/getCallMonitorReducer.js
+++ b/packages/ringcentral-integration/modules/CallMonitor/getCallMonitorReducer.js
@@ -13,9 +13,36 @@ export function getCallMatchedReducer(types) {
     return state;
   };
 }
+
+/**
+ * HACK: for conference call merging glitch
+ */
+export function getCachedCallsFromPresenceReducer(types) {
+  return (state = null, { type, call }) => {
+    switch (type) {
+      case types.updateCallsCaching:
+        call.cached = true;
+
+        if (Array.isArray(state)) {
+          if (state.find(cachedCall => cachedCall.id === call.id)) {
+            return state;
+          }
+          return [...state, call];
+        }
+        return [call];
+      case types.clearCallsCaching:
+      case types.reset:
+        return null;
+      default:
+        return state;
+    }
+  };
+}
+
 /* istanbul ignore next: unnecessary to test getModuleStatusReducer */
 export default function getCallMonitorReducer(types) {
   return combineReducers({
     status: getModuleStatusReducer(types),
+    cachedCallsFromPresence: getCachedCallsFromPresenceReducer(types),
   });
 }

--- a/packages/ringcentral-integration/modules/CallMonitor/getCallMonitorReducer.js
+++ b/packages/ringcentral-integration/modules/CallMonitor/getCallMonitorReducer.js
@@ -21,14 +21,14 @@ export function getCachedCallsFromPresenceReducer(types) {
   return (state = null, { type, call }) => {
     switch (type) {
       case types.updateCallsCaching:
-        call.cached = true;
-
         if (Array.isArray(state)) {
           if (state.find(cachedCall => cachedCall.id === call.id)) {
             return state;
           }
+          call.cached = true;
           return [...state, call];
         }
+        call.cached = true;
         return [call];
       case types.clearCallsCaching:
       case types.reset:

--- a/packages/ringcentral-integration/modules/CallMonitor/index.js
+++ b/packages/ringcentral-integration/modules/CallMonitor/index.js
@@ -13,7 +13,7 @@ import {
   sortByStartTime,
 } from '../../lib/callLogHelpers';
 import ensureExist from '../../lib/ensureExist';
-import { isRing, isOnHold, sortByLastHoldingTimeDesc } from '../Webphone/webphoneHelper';
+import { isRing, isOnHold, sortByLastHoldingTimeDesc, isConferenceSession } from '../Webphone/webphoneHelper';
 
 function matchWephoneSessionWithAcitveCall(sessions, callItem) {
   if (!sessions || !callItem.sipData) {
@@ -194,7 +194,13 @@ export default class CallMonitor extends RcModule {
           };
         }).sort((l, r) => (
           sortByLastHoldingTimeDesc(l.webphoneSession, r.webphoneSession)
-        ));
+        )).filter((callItem) => {
+        // filtering out the conferece during merging
+          if (Array.isArray(cachedCallsFromPresence)) {
+            return !isConferenceSession(callItem.webphoneSession);
+          }
+          return true;
+        });
       },
     );
 

--- a/packages/ringcentral-integration/modules/CallMonitor/index.js
+++ b/packages/ringcentral-integration/modules/CallMonitor/index.js
@@ -141,9 +141,11 @@ export default class CallMonitor extends RcModule {
       () => this._accountInfo.countryCode,
       () => { // gathering all the session datas, including caching
         if (this._webphone && Array.isArray(this._webphone.cachedSessions)) {
-          const sessinObj = [...this._webphone.cachedSessions, ...this._webphone.sessions]
+          const sessinObj = [...this._webphone.sessions, ...this._webphone.cachedSessions]
             .reduce((accum, session) => {
-              accum[session.id] = session;
+              if (!accum[session.id]) {
+                accum[session.id] = session;
+              }
               return accum;
             }, {});
           return Object.values(sessinObj);
@@ -154,17 +156,14 @@ export default class CallMonitor extends RcModule {
         let sessionsCache = sessions || [];
 
         if (Array.isArray(cachedCallsFromPresence)) {
-          const cachedMap = cachedCallsFromPresence
-            .reduce((accum, cachedCall) => {
-              accum[cachedCall.id] = cachedCall;
+          const cachedMap = [...callsFromPresence, ...cachedCallsFromPresence,]
+            .reduce((accum, callItem) => {
+              if (!accum[callItem.id]) {
+                accum[callItem.id] = callItem;
+              }
               return accum;
             }, {});
 
-          callsFromPresence.forEach((data) => {
-            if (!cachedMap[data.id]) {
-              cachedMap[data.id] = data;
-            }
-          });
           callsFromPresence = Object.values(cachedMap);
         }
 
@@ -470,7 +469,7 @@ export default class CallMonitor extends RcModule {
         this._detailedPresence.calls.forEach((call) => {
           if (
             Array.isArray(this.cachedCallsFromPresence)
-            && this.cachedCallsFromPresence.find(data => data.id === call)
+            && this.cachedCallsFromPresence.find(data => data.id === call.id)
           ) {
             return;
           }

--- a/packages/ringcentral-integration/modules/CallMonitor/index.js
+++ b/packages/ringcentral-integration/modules/CallMonitor/index.js
@@ -1,4 +1,5 @@
 import 'core-js/fn/array/find';
+import { equals } from 'ramda';
 import { Module } from '../../lib/di';
 import RcModule from '../../lib/RcModule';
 import moduleStatuses from '../../enums/moduleStatuses';
@@ -152,11 +153,9 @@ export default class CallMonitor extends RcModule {
         }
         return this._webphone && this._webphone.sessions;
       },
-      (callsFromPresence, cachedCallsFromPresence, countryCode, sessions) => {
-        let sessionsCache = sessions || [];
-
+      (callsFromPresence, cachedCallsFromPresence, countryCode, sessions = []) => {
         if (Array.isArray(cachedCallsFromPresence)) {
-          const cachedMap = [...callsFromPresence, ...cachedCallsFromPresence,]
+          const cachedMap = [...callsFromPresence, ...cachedCallsFromPresence]
             .reduce((accum, callItem) => {
               if (!accum[callItem.id]) {
                 accum[callItem.id] = callItem;
@@ -177,8 +176,8 @@ export default class CallMonitor extends RcModule {
             phoneNumber: callItem.to && callItem.to.phoneNumber,
             countryCode,
           });
-          const webphoneSession = matchWephoneSessionWithAcitveCall(sessionsCache, callItem);
-          sessionsCache = sessionsCache.filter(x => x !== webphoneSession);
+          const webphoneSession = matchWephoneSessionWithAcitveCall(sessions, callItem);
+          sessions = sessions.filter(x => x !== webphoneSession);
           return {
             ...callItem,
             from: {
@@ -380,7 +379,7 @@ export default class CallMonitor extends RcModule {
     ) {
       const uniqueNumbers = this._selectors.uniqueNumbers();
       if (
-        this._lastProcessedNumbers !== uniqueNumbers &&
+        !equals(this._lastProcessedNumbers, uniqueNumbers) &&
         (!this._tabManager || this._tabManager.active)
       ) {
         this._lastProcessedNumbers = uniqueNumbers;
@@ -390,7 +389,7 @@ export default class CallMonitor extends RcModule {
       }
       const sessionIds = this._selectors.sessionIds();
       if (
-        this._lastProcessedIds !== sessionIds &&
+        !equals(this._lastProcessedIds, sessionIds) &&
         (!this._tabManager || this._tabManager.active)
       ) {
         this._lastProcessedIds = sessionIds;

--- a/packages/ringcentral-integration/modules/ConferenceCall/index.js
+++ b/packages/ringcentral-integration/modules/ConferenceCall/index.js
@@ -632,18 +632,22 @@ export default class ConferenceCall extends RcModule {
       return conferenceId;
     }
     const { id } = await this.makeConference(true);
-
+    let confereceAccepted = false;
     await Promise.race([
       new Promise((resolve, reject) => {
         const session = this.conferences[id].session;
-        session.on('accepted', () => resolve());
+        session.on('accepted', () => {
+          confereceAccepted = true;
+          resolve();
+        });
         session.on('cancel', () => reject(new Error('conferecing cancel')));
         session.on('failed', () => reject(new Error('conferecing failed')));
         session.on('rejected', () => reject(new Error('conferecing rejected')));
         session.on('terminated', () => reject(new Error('conferecing terminated')));
       }),
       new Promise((resolve, reject) => {
-        setTimeout(() => reject(new Error('conferecing timeout')), this._timout);
+        setTimeout(() => (confereceAccepted ? resolve() : reject(new Error('conferecing timeout')))
+          , this._timout);
       })
     ]);
 

--- a/packages/ringcentral-integration/modules/ConferenceCall/index.js
+++ b/packages/ringcentral-integration/modules/ConferenceCall/index.js
@@ -8,6 +8,7 @@ import getConferenceCallReducer from './getConferenceCallReducer';
 import proxify from '../../lib/proxy/proxify';
 import permissionsMessages from '../RolesAndPermissions/permissionsMessages';
 import conferenceErrors from './conferenceCallErrors';
+import { isConferenceSession } from '../Webphone/webphoneHelper';
 // import webphoneErrors from '../Webphone/webphoneErrors';
 import ensureExist from '../../lib/ensureExist';
 // import sleep from '../../lib/sleep';
@@ -118,8 +119,7 @@ export default class ConferenceCall extends RcModule {
 
     if (this.isMerging && !res) {
       const session = this._webphone.sessions.find(session => session.id === sessionId);
-      res = session && session.to &&
-      session.to.indexOf('conf_') === 0;
+      res = isConferenceSession(session);
     }
 
     return res;

--- a/packages/ringcentral-integration/modules/Webphone/getWebphoneReducer.js
+++ b/packages/ringcentral-integration/modules/Webphone/getWebphoneReducer.js
@@ -175,6 +175,7 @@ export function getCachedSessionsReducer(types) {
   return (state = null, { type, sessions }) => {
     switch (type) {
       case types.updateSessionCaching:
+        sessions.forEach((session) => { session.cached = true ;});
         return sessions;
       case types.clearSessionCaching:
         return null;

--- a/packages/ringcentral-integration/modules/Webphone/index.js
+++ b/packages/ringcentral-integration/modules/Webphone/index.js
@@ -870,6 +870,14 @@ export default class Webphone extends RcModule {
       }
       session.hold();
     });
+
+    // update the caching
+    if (Array.isArray(this.cachedSessions)) {
+      this.cachedSessions.forEach((cache) => {
+        cache.callStatus = sessionStatus.onHold;
+        cache.isOnHold = true;
+      });
+    }
   }
 
   @proxify

--- a/packages/ringcentral-integration/modules/Webphone/webphoneHelper.js
+++ b/packages/ringcentral-integration/modules/Webphone/webphoneHelper.js
@@ -66,3 +66,11 @@ export function sortByLastHoldingTimeDesc(l, r) {
   }
   return sortByCreationTimeDesc(l, r);
 }
+
+/**
+ * HACK: this function is not very reliable, only use it before the merging complete.
+ */
+export function isConferenceSession(session) {
+  return session && session.to &&
+    session.to.indexOf('conf_') === 0;
+}

--- a/packages/ringcentral-widgets/containers/ActiveCallsPage/index.js
+++ b/packages/ringcentral-widgets/containers/ActiveCallsPage/index.js
@@ -21,11 +21,12 @@ function mapToProps(_, {
   const conferenceList = Object.values(conferenceCall.conferences);
   const conference = conferenceList.length ? conferenceList[0] : null;
   let disableMerge;
+  const isWebRTC = callingSettings.callingMode === callingModes.webphone;
 
   if (conference) {
     disableMerge = conferenceCall.isOverload(conference.conference.id);
   } else {
-    disableMerge = false;
+    disableMerge = !isWebRTC;
   }
   return {
     currentLocale: locale.currentLocale,
@@ -47,7 +48,7 @@ function mapToProps(_, {
     brand: brand.fullName,
     showContactDisplayPlaceholder,
     autoLog: !!(callLogger && callLogger.autoLog),
-    isWebRTC: (callingSettings.callingMode === callingModes.webphone),
+    isWebRTC,
     hasConferenceCall: !!conference,
     disableMerge,
   };

--- a/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
+++ b/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import formatNumber from 'ringcentral-integration/lib/formatNumber';
 import callDirections from 'ringcentral-integration/enums/callDirections';
-
+import callingModes from 'ringcentral-integration/modules/CallingSettings/callingModes';
 import withPhone from '../../lib/withPhone';
 import callCtrlLayout from '../../lib/callCtrlLayout';
 import CallCtrlPanel from '../../components/CallCtrlPanel';
@@ -279,6 +279,7 @@ function mapToProps(_, {
     callMonitor,
     contactSearch,
     conferenceCall,
+    callingSettings,
   },
   layout = callCtrlLayout.normalCtrl,
 }) {
@@ -295,10 +296,12 @@ function mapToProps(_, {
   /**
    * button disabled criteria
    */
-  let mergeDisabled = !(currentSession.data && Object.keys(currentSession.data).length) || false;
-  let addDisabled = false;
+  const isWebRTC = callingSettings.callingMode === callingModes.webphone;
+  let mergeDisabled = !(currentSession.data && Object.keys(currentSession.data).length)
+  || !isWebRTC;
+  let addDisabled = !isWebRTC;
 
-  if (conferenceData) {
+  if (conferenceData && isWebRTC) {
     const newVal = conferenceCall.isOverload(conferenceData.conference.id)
     // in case webphone.activeSession has not been updated yet
     || !Object.keys(currentSession).length;


### PR DESCRIPTION
we need to caching the call data when merging to prevent the glitch when merging to conferece call

BREAKING CHANGE: add getCachedCallsFromPresenceReducer

https://jira.ringcentral.com/browse/RCINT-7773